### PR TITLE
fix: a bug in the yaml

### DIFF
--- a/docs/api/spec/treetracker-reporting-api.yaml
+++ b/docs/api/spec/treetracker-reporting-api.yaml
@@ -407,7 +407,7 @@ paths:
                       number: 10
                     links:
                       prev: null,
-                      next: "capture/statistics/card?card_title=planters&limit=7&offset=7
+                      next: capture/statistics/card?card_title=planters&limit=7&offset=7
                 properties:
                   card_information:
                     type: array


### PR DESCRIPTION
This extra double quote will cause swagger to fail to parse the yaml