### PR TITLE
Matched captures statistic

### DIFF
--- a/__tests__/integration/capture_denormalized.spec.js
+++ b/__tests__/integration/capture_denormalized.spec.js
@@ -364,6 +364,7 @@ describe('capture_denormalized', () => {
             'species',
             'captures',
             'unverified_captures',
+            'matched_captures',
             'top_planters',
             'trees_per_planters',
             'last_updated_at',
@@ -381,6 +382,7 @@ describe('capture_denormalized', () => {
             'total',
             'unverified_captures',
           ]);
+          expect(res.body.matched_captures).to.have.keys(['total', 'matched_captures']);
           expect(res.body.top_planters).to.have.keys([
             'average',
             'top_planters',
@@ -396,6 +398,7 @@ describe('capture_denormalized', () => {
           checkObjectProperties(
             res.body.unverified_captures.unverified_captures,
           );
+          checkObjectProperties(res.body.matched_captures.matched_captures);
           checkObjectProperties(res.body.top_planters.top_planters);
           checkObjectProperties(res.body.trees_per_planters.trees_per_planters);
           checkObjectProperties(res.body.catchments.catchments);
@@ -426,7 +429,7 @@ describe('capture_denormalized', () => {
           .end(function (err, res) {
             if (err) return done(err);
             expect(res.body.message).to.eql(
-              '"card_title" must be one of [planters, species, captures, unverified_captures, top_planters, trees_per_planters, catchments, gender_details, approval_rates]',
+              '"card_title" must be one of [planters, species, captures, unverified_captures, matched_captures, top_planters, trees_per_planters, catchments, gender_details, approval_rates]',
             );
             return done();
           });

--- a/database/migrations/20230724231226-add-tree-id-column.js
+++ b/database/migrations/20230724231226-add-tree-id-column.js
@@ -1,0 +1,53 @@
+'use strict';
+
+var dbm;
+var type;
+var seed;
+var fs = require('fs');
+var path = require('path');
+var Promise;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+  Promise = options.Promise;
+};
+
+exports.up = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20230724231226-add-tree-id-column-up.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports.down = function(db) {
+  var filePath = path.join(__dirname, 'sqls', '20230724231226-add-tree-id-column-down.sql');
+  return new Promise( function( resolve, reject ) {
+    fs.readFile(filePath, {encoding: 'utf-8'}, function(err,data){
+      if (err) return reject(err);
+      console.log('received data: ' + data);
+
+      resolve(data);
+    });
+  })
+  .then(function(data) {
+    return db.runSql(data);
+  });
+};
+
+exports._meta = {
+  "version": 1
+};

--- a/database/migrations/sqls/20230724231226-add-tree-id-column-down.sql
+++ b/database/migrations/sqls/20230724231226-add-tree-id-column-down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE capture_denormalized DROP COLUMN tree_id;

--- a/database/migrations/sqls/20230724231226-add-tree-id-column-up.sql
+++ b/database/migrations/sqls/20230724231226-add-tree-id-column-up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE capture_denormalized ADD COLUMN tree_id uuid;

--- a/server/handlers/captureHandler.js
+++ b/server/handlers/captureHandler.js
@@ -65,6 +65,7 @@ const captureStatisticsGetCardQuerySchema = Joi.object({
       'species',
       'captures',
       'unverified_captures',
+      'matched_captures',
       'top_planters',
       'trees_per_planters',
       'catchments',

--- a/server/models/Capture.js
+++ b/server/models/Capture.js
@@ -94,6 +94,8 @@ class Capture {
     topCatchment = [],
     genderCount = [],
     approvalRates,
+    totalMatchedCaptures = undefined,
+    topMatchedCaptures = [],
   }) {
     const planters = {
       total: totalGrowers,
@@ -170,11 +172,22 @@ class Capture {
       };
     });
 
+    const matched_captures = {
+      total: totalMatchedCaptures,
+      matched_captures: topMatchedCaptures.map(({ planting_organization_name, count }) => {
+        return {
+          name: planting_organization_name,
+          number: count,
+        }
+      })
+    }
+
     return {
       planters,
       species,
       captures,
       unverified_captures,
+      matched_captures,
       top_planters,
       trees_per_planters,
       last_updated_at,
@@ -203,6 +216,8 @@ class Capture {
       topCatchment,
       genderCount,
       approvalRates,
+      totalMatchedCaptures,
+      topMatchedCaptures,
     } = await this._captureRepository.getStatistics(filter);
 
     return this.constructor.generateFormattedResponse({
@@ -223,6 +238,8 @@ class Capture {
       topCatchment,
       genderCount,
       approvalRates,
+      totalMatchedCaptures,
+      topMatchedCaptures,
     });
   }
 

--- a/server/repositories/CaptureRepository.js
+++ b/server/repositories/CaptureRepository.js
@@ -2,8 +2,8 @@ const BaseRepository = require('./BaseRepository');
 
 class CaptureRepository extends BaseRepository {
   constructor(session) {
-    super('reporting.capture_denormalized', session);
-    this._tableName = 'reporting.capture_denormalized';
+    super('capture_denormalized', session);
+    this._tableName = 'capture_denormalized';
     this._session = session;
   }
 
@@ -55,7 +55,6 @@ class CaptureRepository extends BaseRepository {
     const whereBuilder = function (object, builder) {
       const result = builder;
       const filterObject = { ...object };
-      console.log('FILTEROBJ', filterObject)
       delete filterObject.card_title;
       if (filterObject.capture_created_start_date) {
         result.where(
@@ -132,7 +131,7 @@ class CaptureRepository extends BaseRepository {
           'planter_last_name',
           'planter_identifier',
         )
-          .from('reporting.capture_denormalized')
+          .from('capture_denormalized')
           .where((builder) => whereBuilder(filter, builder))
           .as('planters');
       });
@@ -148,7 +147,7 @@ class CaptureRepository extends BaseRepository {
           'planting_organization_name',
           'planting_organization_uuid',
         )
-          .from('reporting.capture_denormalized')
+          .from('capture_denormalized')
           .where((builder) => whereBuilder(filter, builder))
           .groupBy(
             'planting_organization_uuid',
@@ -178,7 +177,7 @@ class CaptureRepository extends BaseRepository {
       .avg('totalPlanters')
       .from(function () {
         this.count('* as totalPlanters')
-          .from('reporting.capture_denormalized')
+          .from('capture_denormalized')
           .where((builder) => whereBuilder(filter, builder))
           .groupBy(
             'planter_first_name',
@@ -237,7 +236,7 @@ class CaptureRepository extends BaseRepository {
                 `count(*) as count, planting_organization_name, planting_organization_uuid`,
               ),
             )
-              .from('reporting.capture_denormalized')
+              .from('capture_denormalized')
               .where((builder) => whereBuilder(filter, builder))
               .groupBy(
                 'planting_organization_uuid',
@@ -266,7 +265,7 @@ class CaptureRepository extends BaseRepository {
             `count(*) as count, planting_organization_name, planting_organization_uuid`,
           ),
         )
-          .from('reporting.capture_denormalized')
+          .from('capture_denormalized')
           .where((builder) => whereBuilder(filter, builder))
           .groupBy(
             'planting_organization_uuid',
@@ -288,7 +287,7 @@ class CaptureRepository extends BaseRepository {
       .avg('totalCatchment')
       .from(function () {
         this.count('* as totalCatchment')
-          .from('reporting.capture_denormalized')
+          .from('capture_denormalized')
           .where((builder) => cachmentWhereBuilder(filter, builder))
           .groupBy('catchment')
           .as('catchments');
@@ -313,7 +312,7 @@ class CaptureRepository extends BaseRepository {
           'gender',
         )
           .where((builder) => whereBuilder(filter, builder))
-          .from('reporting.capture_denormalized')
+          .from('capture_denormalized')
           .as('planters');
       })
       .groupBy('gender')

--- a/server/repositories/CaptureRepository.js
+++ b/server/repositories/CaptureRepository.js
@@ -2,8 +2,8 @@ const BaseRepository = require('./BaseRepository');
 
 class CaptureRepository extends BaseRepository {
   constructor(session) {
-    super('capture_denormalized', session);
-    this._tableName = 'capture_denormalized';
+    super('reporting.capture_denormalized', session);
+    this._tableName = 'reporting.capture_denormalized';
     this._session = session;
   }
 
@@ -55,6 +55,7 @@ class CaptureRepository extends BaseRepository {
     const whereBuilder = function (object, builder) {
       const result = builder;
       const filterObject = { ...object };
+      console.log('FILTEROBJ', filterObject)
       delete filterObject.card_title;
       if (filterObject.capture_created_start_date) {
         result.where(
@@ -131,7 +132,7 @@ class CaptureRepository extends BaseRepository {
           'planter_last_name',
           'planter_identifier',
         )
-          .from('capture_denormalized')
+          .from('reporting.capture_denormalized')
           .where((builder) => whereBuilder(filter, builder))
           .as('planters');
       });
@@ -147,7 +148,7 @@ class CaptureRepository extends BaseRepository {
           'planting_organization_name',
           'planting_organization_uuid',
         )
-          .from('capture_denormalized')
+          .from('reporting.capture_denormalized')
           .where((builder) => whereBuilder(filter, builder))
           .groupBy(
             'planting_organization_uuid',
@@ -177,7 +178,7 @@ class CaptureRepository extends BaseRepository {
       .avg('totalPlanters')
       .from(function () {
         this.count('* as totalPlanters')
-          .from('capture_denormalized')
+          .from('reporting.capture_denormalized')
           .where((builder) => whereBuilder(filter, builder))
           .groupBy(
             'planter_first_name',
@@ -236,7 +237,7 @@ class CaptureRepository extends BaseRepository {
                 `count(*) as count, planting_organization_name, planting_organization_uuid`,
               ),
             )
-              .from('capture_denormalized')
+              .from('reporting.capture_denormalized')
               .where((builder) => whereBuilder(filter, builder))
               .groupBy(
                 'planting_organization_uuid',
@@ -265,7 +266,7 @@ class CaptureRepository extends BaseRepository {
             `count(*) as count, planting_organization_name, planting_organization_uuid`,
           ),
         )
-          .from('capture_denormalized')
+          .from('reporting.capture_denormalized')
           .where((builder) => whereBuilder(filter, builder))
           .groupBy(
             'planting_organization_uuid',
@@ -287,7 +288,7 @@ class CaptureRepository extends BaseRepository {
       .avg('totalCatchment')
       .from(function () {
         this.count('* as totalCatchment')
-          .from('capture_denormalized')
+          .from('reporting.capture_denormalized')
           .where((builder) => cachmentWhereBuilder(filter, builder))
           .groupBy('catchment')
           .as('catchments');
@@ -312,7 +313,7 @@ class CaptureRepository extends BaseRepository {
           'gender',
         )
           .where((builder) => whereBuilder(filter, builder))
-          .from('capture_denormalized')
+          .from('reporting.capture_denormalized')
           .as('planters');
       })
       .groupBy('gender')
@@ -370,7 +371,7 @@ class CaptureRepository extends BaseRepository {
         .whereNotNull('tree_id')
         .where((builder) => whereBuilder({ ...filter, approved: true }, builder));
 
-    //top matched captures (by organization)
+    // top matched captures (by organization)
     const topMatchedCapturesQuery = knex(this._tableName)
           .select(knex.raw('planting_organization_name, count(*) as count'))
           .whereNotNull('tree_id')
@@ -403,6 +404,7 @@ class CaptureRepository extends BaseRepository {
             await topUnverifiedCapturesQuery.cache();
           return { topUnverifiedCaptures };
         }
+
         case 'top_planters': {
           const topPlanters = await topPlantersQuery.cache();
           return { topPlanters };
@@ -421,7 +423,6 @@ class CaptureRepository extends BaseRepository {
           return { approvalRates };
         }
         case 'matched_captures': {
-          console.log('MATCHED CAPTURES IS CALLED')
           const topMatchedCaptures = await topMatchedCapturesQuery.cache();
           return { topMatchedCaptures };
         }


### PR DESCRIPTION
## Description
A new reporting card statistic for matched captures is implemented.

**Issue(s) addressed**
- Resolves #72 

**What kind of change(s) does this PR introduce?**
- [x] Enhancement
- [ ] Bug fix
- [ ] Refactor

**Please check if the PR fulfils these requirements**
- [X] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## Issue

**What is the current behavior?**
There is no matched captures statistic.

**What is the new behavior?**
![image](https://github.com/Greenstand/treetracker-reporting/assets/15161954/cdcb9a7d-f05f-495b-8907-39bb2146f37d)
The `capture/statistics` and `capture/statistics/card?card_title=matched_captures` endpoints return `matched_captures` statistic.

## Breaking change

**Does this PR introduce a breaking change?**
No.

## Other useful information
The image for new behavior is based on test data. The `capture_denormalized` table needs to be populated using an Airflow task, which is not yet updated.
